### PR TITLE
Fixed bug when unpack was not passed a target dir.

### DIFF
--- a/src/packager.c
+++ b/src/packager.c
@@ -103,6 +103,11 @@ int parse_args(int argc, char **argv) {
 		return -1;
 	}
 	if (!packager.rootName && !packager.printMeta) {
+		/* if we are going to unpack then we need a target dir */
+		if(!packager.pack) {
+			printf("Invalid usage - no target directory specified for unpacking. See kpack --help.\n");
+			return -1;
+		}
 		printf("Invalid usage - no model specified. See kpack --help.\n");
 	}
 	


### PR DESCRIPTION
I am also curious when extracting the package why does it not also create a package.config file?

PR to address: https://github.com/KnightOS/KnightOS/issues/348

Ran into this while testing https://github.com/KnightOS/KnightOS/issues/305 (wanted to try uploading a new version of an existing package).