### PR TITLE
Closed dangling file descriptors when packing.

### DIFF
--- a/src/packager.c
+++ b/src/packager.c
@@ -1,3 +1,5 @@
+#include <errno.h>
+
 #include "common.h"
 #include "checksums.h"
 #include "version.h.gen"
@@ -346,6 +348,11 @@ void writeFileToPackage(char *f, char *relpath) {
 		//
 		// MD5 checksum
 		// directly write the thing
+	}
+
+	/* clean up input file */
+	if(in && fclose(in)) {
+		printf("Error: Closed %s and this happened:\n\t%s\n", filename, strerror(errno));
 	}
 }
 


### PR DESCRIPTION
Trying to figure out some issues with MacOS when packing (packing works roughly 2/3 of the time). Fixed this issue in case I was sometimes running up against the open FD limit.

Valgrind output before fix:
```
Successfully wrote community/mytest:0.5.0 to mytest2.pkg.
==9361==
==9361== FILE DESCRIPTORS: 53 open at exit.
==9361== Open file descriptor 55: ./testing.text
==9361==    at 0x261622: open$NOCANCEL (in /usr/lib/system/libsystem_kernel.dylib)
==9361==    by 0x100002DDC: writeFileToPackage (in ../kpack/bin/kpack)
==9361==    by 0x1000031AC: writeModelRecursive (in ../kpack/bin/kpack)
==9361==    by 0x10000327E: writeModel (in ../kpack/bin/kpack)
==9361==    by 0x100001D55: main (in ../kpack/bin/kpack)
```

Valgrind output after fix:
```
Successfully wrote community/mytest:0.5.0 to mytest2.pkg.
==9108==
==9108== FILE DESCRIPTORS: 3 open at exit.
==9108== Open file descriptor 2: /dev/ttys000
==9108==    <inherited from parent>
==9108==
==9108== Open file descriptor 1: /dev/ttys000
==9108==    <inherited from parent>
==9108==
==9108== Open file descriptor 0: /dev/ttys000
==9108==    <inherited from parent>
```