### PR TITLE
Now using nftw to traverse dirs when packing.

### DIFF
--- a/src/packager.h
+++ b/src/packager.h
@@ -1,6 +1,13 @@
 #ifndef INC_PKGR
 #define INC_PKGR
 
+/* defines for nftw() */
+#define _XOPEN_SOURCE 1
+#define _XOPEN_SOURCE_EXTENDED 1
+
+/* used to calculate how many FDs we allow nftw to use */
+#define NUM_FDS_TO_RESERVE (3)
+
 extern void initRuntime();
 extern int parse_args(int argc, char **argv);
 extern int parse_metadata();


### PR DESCRIPTION
I apologize for the ugly diff :( Wanted to submit this just to get your feedback if you have the time. I consider it a WIP.

Needs:
- To be tested on linux and cygwin.
- To be tested with more packages.

Fixes:
- Problems when packing cannot be completed on MacOS due to opendir(). This may occur on other systems as well (don't know).
- One off file number counts (more below).

Other:
- This appears to run faster than the previous version. I don't have benchmarks unfortunately, since the previous kpack version cannot reliably pack for me.
## One off file number counts

On the packages I have tested the total file number count for the package is always off by one (the prev kpack has +1). I believe this is the case because it is counting the root dir of the package. This would also explain why with the prev kpack the following happens for me:

```
kpack -e orig-ver.pkg throwaway/
Extracting community/mytest:0.5.0 to throwaway
Extracting /bin/tunnel...
Extracting /package.config...
Extracting /share/icons/tunnel.img...
Extracting /var/applications/tunnel.app...
Extracting ...
Unable to open throwaway/. for writing.
```

I am unsure how the +1 file count effects other parts of the KnightOS ecosystem. I also need to test against the official 1.0.10 release and make sure that I didn't introduce this bug.
